### PR TITLE
Added fix in order for unit tests to pass successfully

### DIFF
--- a/ws/ws/src/test/java/org/kaazing/gateway/client/impl/wseb/WebSocketEmulatedHandlerTest.java
+++ b/ws/ws/src/test/java/org/kaazing/gateway/client/impl/wseb/WebSocketEmulatedHandlerTest.java
@@ -119,6 +119,10 @@ public class WebSocketEmulatedHandlerTest {
 
         handler.processConnect(channel, uri, new String[]{"foo"});
         context.assertIsSatisfied();
+
+        WebSocketEmulatedHandler.createHandlerFactory = CreateHandlerImpl.FACTORY;
+        WebSocketEmulatedHandler.upstreamHandlerFactory = UpstreamHandlerImpl.FACTORY;
+        WebSocketEmulatedHandler.downstreamHandlerFactory = DownstreamHandlerImpl.FACTORY;
     }
 
     /*
@@ -191,6 +195,10 @@ public class WebSocketEmulatedHandlerTest {
 
         handler.processConnect(channel, uri, protocols);
         context.assertIsSatisfied();
+
+        WebSocketEmulatedHandler.createHandlerFactory = CreateHandlerImpl.FACTORY;
+        WebSocketEmulatedHandler.upstreamHandlerFactory = UpstreamHandlerImpl.FACTORY;
+        WebSocketEmulatedHandler.downstreamHandlerFactory = DownstreamHandlerImpl.FACTORY;
     }
 
 }


### PR DESCRIPTION
Added the lines:

 > WebSocketEmulatedHandler.createHandlerFactory = CreateHandlerImpl.FACTORY;
    WebSocketEmulatedHandler.upstreamHandlerFactory = UpstreamHandlerImpl.FACTORY;
    WebSocketEmulatedHandler.downstreamHandlerFactory = DownstreamHandlerImpl.FACTORY;

at the end of both tests in the "org.kaazing.gateway.client.impl.wseb.WebSocketEmulatedHandlerTest" class(testProcessOpen and testProcessFailed) in order to fix a build error on Ubuntu regarding some failing unit tests(more details in [build error](https://github.com/kaazing/java.client/issues/7)).